### PR TITLE
Add Steam OpenID setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,15 @@ Feel free to check out the [Strapi GitHub repository](https://github.com/strapi/
 ---
 
 <sub>🤫 Psst! [Strapi is hiring](https://strapi.io/careers).</sub>
+
+## Steam Authentication
+
+To enable Steam sign-in, set the following environment variables before running Strapi:
+
+```
+STEAM_API_KEY=your_steam_api_key
+STEAM_RETURN_URL=https://your-strapi-host/connect/steam/callback
+STEAM_REALM=https://your-strapi-host
+```
+
+These values are used by the `passport-steam` strategy configured in `src/extensions/users-permissions/strapi-server.js`.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.0.0",
     "styled-components": "^6.0.0"
+    ,"passport-steam": "^1.0.11"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/extensions/users-permissions/content-types/user/schema.json
+++ b/src/extensions/users-permissions/content-types/user/schema.json
@@ -1,0 +1,71 @@
+{
+  "kind": "collectionType",
+  "collectionName": "up_users",
+  "info": {
+    "singularName": "user",
+    "pluralName": "users",
+    "displayName": "User"
+  },
+  "options": {
+    "draftAndPublish": false,
+    "timestamps": true
+  },
+  "pluginOptions": {
+    "users-permissions": {
+      "config": {
+        "restricted": true
+      }
+    }
+  },
+  "attributes": {
+    "username": {
+      "type": "string",
+      "minLength": 3,
+      "required": true
+    },
+    "email": {
+      "type": "email",
+      "minLength": 6,
+      "required": true,
+      "unique": true
+    },
+    "provider": {
+      "type": "string"
+    },
+    "password": {
+      "type": "password",
+      "minLength": 6,
+      "private": true
+    },
+    "resetPasswordToken": {
+      "type": "string",
+      "private": true
+    },
+    "confirmationToken": {
+      "type": "string",
+      "private": true
+    },
+    "confirmed": {
+      "type": "boolean",
+      "default": false
+    },
+    "blocked": {
+      "type": "boolean",
+      "default": false
+    },
+    "steamId": {
+      "type": "string",
+      "unique": true
+    },
+    "avatar": {
+      "type": "media",
+      "allowedTypes": ["images"],
+      "multiple": false
+    },
+    "role": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "plugin::users-permissions.role"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `passport-steam` dependency
- extend the Users & Permissions user schema with `steamId`
- document Steam environment variables for authentication

## Testing
- `npm run build` *(fails: `strapi` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d49323cdc8323aa1399ae1b08765d